### PR TITLE
Added grunt-sync to Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,11 +33,11 @@ module.exports = function (grunt) {
             },
             update: {
                 files: ['<%= yeoman.app %>/{layout,snippets,templates}/*.liquid'],
-                tasks: ['copy']
+                tasks: ['sync']
             },
             config: {
                 files: ['<%= yeoman.app %>/config/*.{html,json}'],
-                tasks: ['copy']
+                tasks: ['sync']
             }
         },
         clean: {
@@ -120,6 +120,21 @@ module.exports = function (grunt) {
                         '<%= yeoman.app %>/styles/{,*/}*.css'
                     ]
                 }
+            }
+        },
+        sync: {
+            main: {
+                files: [{
+                  cwd: '<%= yeoman.app %>',
+                  src: [
+                            'assets/*',
+                            'config/*',
+                            'layout/*',
+                            'snippets/*',
+                            'templates/*',
+                        ],
+                  dest: '<%= yeoman.dist %>',
+                }]
             }
         },
         copy: {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "grunt-contrib-coffee": "~0.4.0",
     "grunt-contrib-uglify": "~0.1.1",
     "grunt-contrib-compass": "~0.1.2",
+    "grunt-sync": "~0.0.6",
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-cssmin": "~0.4.1",
     "grunt-contrib-connect": "0.1.2",


### PR DESCRIPTION
This fixes the copy command, which allows shopify theme editor to do its job correctly by adding grunt-sync.
