### PR TITLE
Update Grunt FontAwesome path

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -154,7 +154,7 @@ module.exports = function (grunt) {
                     ]
                 },{
                     expand: true,
-                    cwd: '<%= config.app %>/bower_components/font-awesome/font',
+                    cwd: '<%= config.app %>/bower_components/fontawesome/fonts',
                     dest: '<%= config.dist %>/assets',
                     src: [
                         '*'


### PR DESCRIPTION
The FontAwesome file path was outdated, and, as a result, the font files were not being passed to the dist folder on build. Resolves #18 