### PR TITLE
Upgrade dependencies, fix Font Awesome inclusion, spruce up README

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,6 @@
 {
     "node": true,
     "browser": true,
-    "es5": true,
     "esnext": true,
     "bitwise": true,
     "camelcase": true,

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013 Luke Bussey
+Copyright (c) 2016 Luke Bussey
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,3 @@ Working with the Shopify Theme Manager (live updating)
 5. Run `grunt live` which will build the dist folder for Foundationify.
 6. In the Shopify Theme Manager, force a deployment to upload the theme.
 7. Start making your changes and see them uploaded immediately to your store.
-
-MIT Open Source License
-=======================
-Copyright (c) 2013 Luke Bussey
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-Foundationify — A [Foundation](http://foundation.zurb.com/) 5 based theme for Shopify
-========================================================
+# Foundationify
+
+[![devDependency Status](https://david-dm.org/lukebussey/foundationify/dev-status.svg)](https://david-dm.org/lukebussey/foundationify#info=devDependencies)
 
 Foundationify is a theme for Shopify based on the responsive Zurb [Foundation](http://foundation.zurb.com/) 5 framework.
 

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,13 @@
 {
   "name": "foundationify",
-  "version": "0.0.4",
+  "version": "0.0.5",
+  "authors": [
+    "Luke Bussey <luke.bussey@gmail.com>"
+  ],
+  "license": "MIT",
+  "private": true,
   "dependencies": {
     "foundation": "~5.4.7",
     "fontawesome": "~4.2.0"
-  },
-  "devDependencies": {}
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,6 @@
   "private": true,
   "dependencies": {
     "foundation": "~5.4.7",
-    "fontawesome": "~4.2.0"
+    "fontawesome": "~4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-open": "~0.2.0",
     "grunt-sync": "~0.5.2",
-    "grunt-usemin": "~3.0.0",
+    "grunt-usemin": "~3.1.0",
     "load-grunt-tasks": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "foundationify",
   "version": "0.0.5",
+  "author": "Luke Bussey <luke.bussey@gmail.com>",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/lukebussey/foundationify.git"

--- a/package.json
+++ b/package.json
@@ -5,27 +5,33 @@
     "type": "git",
     "url": "https://github.com/lukebussey/foundationify.git"
   },
-  "dependencies": {},
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://opensource.org/licenses/MIT"
+    }
+  ],
+  "engines": {
+    "node": ">= 0.12.0",
+    "npm": ">=2.1.5"
+  },
   "devDependencies": {
     "grunt": "~0.4.0",
-    "grunt-contrib-clean": "0.4.0",
-    "grunt-contrib-coffee": "~0.4.0",
-    "grunt-contrib-compass": "~0.1.2",
-    "grunt-contrib-concat": "~0.1.2",
-    "grunt-contrib-connect": "0.1.2",
-    "grunt-contrib-copy": "~0.4.0",
-    "grunt-contrib-cssmin": "~0.4.1",
-    "grunt-contrib-htmlmin": "0.1.1",
-    "grunt-contrib-imagemin": "0.1.2",
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-uglify": "~0.1.1",
+    "grunt-contrib-clean": "~1.0.0",
+    "grunt-contrib-coffee": "~1.0.0",
+    "grunt-contrib-compass": "~1.1.0",
+    "grunt-contrib-concat": "1.0.0",
+    "grunt-contrib-connect": "~0.11.2",
+    "grunt-contrib-copy": "~0.8.2",
+    "grunt-contrib-cssmin": "~0.14.0",
+    "grunt-contrib-htmlmin": "~0.6.0",
+    "grunt-contrib-imagemin": "~1.0.0",
+    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-contrib-uglify": "~0.11.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-open": "~0.2.0",
-    "grunt-sync": "~0.0.6",
-    "grunt-usemin": "~0.1.9",
-    "load-grunt-tasks": "^1.0.0"
-  },
-  "engines": {
-    "node": ">=0.8.0"
+    "grunt-sync": "~0.5.2",
+    "grunt-usemin": "~3.0.0",
+    "load-grunt-tasks": "^3.0.0"
   }
 }

--- a/styles/_settings.scss
+++ b/styles/_settings.scss
@@ -1,6 +1,6 @@
 // Foundationify Settings
 
-$fontAwesomePath: ".";
+$fa-font-path: ".";
 
 // Add any Foundation settings here. E.g.
 // $body-bg: #fff;


### PR DESCRIPTION
Grunt wasn't compiling at all. Upgraded the dependencies and made a few minor tweaks to accomodate. Fixes #27 (and also #23 which was temporarily stymied because the poster downgraded NPM).

Font Awesome wasn't being included because of a changed Foundation variable. Fixes #28 through a simple rename.

Finally, I spruced up README! I added in a dependency tracker through [David DM](https://david-dm.org/lukebussey/foundationify). I removed the tagline from the main header since it is also included beneath it. I removed the MIT license transcluded in README, since it is also included in the LICENSE file. And I also added the author name and URL to the packages, and updated semvers and years.
